### PR TITLE
Remove level parameter from createRpcClient

### DIFF
--- a/src/ChargerSimulator.ts
+++ b/src/ChargerSimulator.ts
@@ -56,7 +56,6 @@ export class ChargerSimulator {
       log.info(`Will send messages to Central System at ${this.config.centralSystemEndpoint}`)
     } else {
       const {remote} = await createRpcClient(
-        0,
         async () => {
           ws = new WebSocket(
             this.config.centralSystemEndpoint + "/" + this.config.chargerIdentity,


### PR DESCRIPTION
This fixes incompatibility with the `@push-rpc` package.

```
TSError: ⨯ Unable to compile TypeScript:
node_modules/charger-simulator/src/ChargerSimulator.ts:68:9 - error TS2554: Expected 1-2 arguments, but got 3.

 68         {
            ~
 69           local: this.chargePoint,
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
...
 88           },
    ~~~~~~~~~~~~
 89         }
    ~~~~~~~~~
```
