### PR TITLE
Implement more OCPP commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,9 +72,10 @@ will result in StartTransaction and multiple MeterValues to be sent to central s
 *RemoteStopTransaction*. Will stop running transaction.
 
 *GetConfiguration*. Return charge point configuration.
+
 *ChangeConfiguration*. Change charge point configuration.
 
-*ReserveNow, CancelReservation, Reset*. Return 'Accepted', but do nothing.
+*ChangeAvailability, ReserveNow, CancelReservation, Reset*. Return 'Accepted', but do nothing.
 
 All other methods are not implemented.
 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ will result in StartTransaction and multiple MeterValues to be sent to central s
 
 *ChangeConfiguration*. Change charge point configuration.
 
-*ChangeAvailability, ReserveNow, CancelReservation, Reset*. Return 'Accepted', but do nothing.
+*ChangeAvailability, ClearCache, ReserveNow, CancelReservation, Reset*. Return 'Accepted', but do nothing.
 
 All other methods are not implemented.
 

--- a/src/ChargerSimulator.ts
+++ b/src/ChargerSimulator.ts
@@ -220,6 +220,10 @@ export class ChargerSimulator {
       return {status: "Accepted"}
     },
 
+    ClearCache: async(req) => {
+      return {status: "Accepted"}
+    },
+
     ReserveNow: async (req) => {
       return {status: "Accepted"}
     },

--- a/src/ChargerSimulator.ts
+++ b/src/ChargerSimulator.ts
@@ -216,6 +216,10 @@ export class ChargerSimulator {
       return {status: "Accepted"}
     },
 
+    ChangeAvailability: async(req) => {
+      return {status: "Accepted"}
+    },
+
     ReserveNow: async (req) => {
       return {status: "Accepted"}
     },

--- a/src/chargerSimulatorCli.ts
+++ b/src/chargerSimulatorCli.ts
@@ -88,6 +88,7 @@ const usageSections = [
     
     --
     b:        send BootNotification
+    o:        send BootNotification with optional parameters
     d:        send DataTransfer
     i:        disconnect from Central System
     
@@ -119,6 +120,16 @@ const usageSections = [
       simulator.centralSystem.BootNotification({
         chargePointVendor: "OC",
         chargePointModel: "OCX",
+      }),
+    o: () =>
+      simulator.centralSystem.BootNotification({
+        chargePointVendor: "OC",
+        chargePointModel: "OCX",
+        chargePointSerialNumber: "1234-5678",
+        meterSerialNumber: "1234-5678-AA-BB",
+        firmwareVersion: "AA-001",
+        iccid: "OMEGA-PEPEGA",
+        imsi: "ENERGY-001",
       }),
     d: () =>
       simulator.centralSystem.DataTransfer({


### PR DESCRIPTION
This adds support for a few more methods:
- [x] `ChangeAvailability` which will simply always accept
- [x] `ClearCache` which will simply always accept
- [x] second `BootNotification` including optional data